### PR TITLE
Fixed log messages not being escaped

### DIFF
--- a/lib/winston-postgre.js
+++ b/lib/winston-postgre.js
@@ -36,8 +36,8 @@ PostgreSQL.prototype.log = function (level, msg, meta, callback) {
     } else {
       currentDate = moment().format('YYYY-MM-DD HH:mm:ss.SSS');
     }
-    var sqlInsert = "INSERT INTO $1 (logdate, level, message) VALUES ('$2', '$3', '$4');";
-    var sqlParams = [this.table, currentDate, level, msg];
+    var sqlInsert = "INSERT INTO " + this.table + " (logdate, level, message) VALUES ($1::timestamp, $2, $3);";
+    var sqlParams = [currentDate, level, msg];
     var client = new pg.Client(this.connectionString);   
 
     client.connect(function (err) { 

--- a/lib/winston-postgre.js
+++ b/lib/winston-postgre.js
@@ -36,14 +36,15 @@ PostgreSQL.prototype.log = function (level, msg, meta, callback) {
     } else {
       currentDate = moment().format('YYYY-MM-DD HH:mm:ss.SSS');
     }
-    var sqlInsert = "INSERT INTO " + this.table + " (logdate, level, message) VALUES ('" + currentDate + "', '" + level + "', '" + msg + "');";
+    var sqlInsert = "INSERT INTO $1 (logdate, level, message) VALUES ('$2', '$3', '$4');";
+    var sqlParams = [this.table, currentDate, level, msg];
     var client = new pg.Client(this.connectionString);   
 
     client.connect(function (err) { 
       if (err) {
         self.emit('Error connecting to the database', err);
       }
-      client.query(sqlInsert, function (err) {
+      client.query(sqlInsert, sqlParams, function (err) {
         if (err) {
           self.emit('error', err);
         }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "main": "./lib/winston-postgre.js",
   "dependencies": {
     "moment-timezone": "^0.2.1",
-    "pg": "^3.4.0",
-    "winston": "^0.7.3"
+    "pg": "^4.4.0",
+    "winston": "^1.0.0"
   }
 }


### PR DESCRIPTION
A ton of my log messages were not showing up in pg. Turns out the insert query wasn't parameterized! Queries with non sanitized log messages is pretty dangerous as well.

This pull request fixes the issue and also updates the dependency versions. 
